### PR TITLE
Fix for Angular 1.3.7

### DIFF
--- a/st-blurred-dialog.js
+++ b/st-blurred-dialog.js
@@ -62,8 +62,7 @@ angular.module("stBlurredDialog",[])
 	// This directive is used to show the modal dialog
 	.directive('stBlurredDialogOverlay', [function(){
 		return {
-			restrict: "E",
-			scope: {},
+			restrict: "E",			
 			replace: true,
 			template: 	"<div ng-if='model.isOpen' class='st-blurred-region-overlay'>" +
 						"<div style='text-align:right;'><button ng-click='close()' class='st-blurred-region-close'>&#10006;</button></div>" +


### PR DESCRIPTION
It seems something has changed related to isolate scope in anglular 1.3. I suspect this

https://docs.angularjs.org/guide/migration#isolate-scope-only-exposed-to-directives-with-scope-property

Anyway, this fixes the issue with 1.3.7

Fixes #2 
